### PR TITLE
Split repotool into two binaries: one which output JSON and the other for database insertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .DS_Store
 
 repotool
+!cmd/repotool
+repotool-db
+!cmd/repotool-db
 repotool.conf
 log
 pid

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 PKG  = github.com/DevMine/repotool
-EXEC = repotool
 
 all: check test build
 
 install:
-	go install ${PKG}
+	go install ${PKG}/cmd/repotool
+	go install ${PKG}/cmd/repotool-db
 
 build:
-	go build -o ${EXEC} ${PKG}
+	go build ${PKG}/cmd/repotool
+	go build ${PKG}/cmd/repotool-db
 
 test:
 	go test ${PKG}/...
@@ -15,6 +16,7 @@ test:
 # FIXME: we shall compile libgit2 statically with git2go to prevent libgit2
 # from being a dependency to run repotool
 deps:
+	go get -u github.com/golang/glog
 	go get -u github.com/libgit2/git2go
 	go get -u github.com/lib/pq
 	go get -u github.com/spaolacci/murmur3
@@ -31,4 +33,4 @@ cover:
 	go test -cover ${PKG}/...
 
 clean:
-	rm -f ./${EXEC}
+	rm -f ./repotool ./repotool-db

--- a/README.md
+++ b/README.md
@@ -147,40 +147,45 @@ Or you can download a binary for your platform from the DevMine project's
 `repotool` produces JSON, provided that you feed it with a path to a source code
 repository managed by a VCS which can be either in the form of a directory or a
 tar archive. By default, informative messages are outputted to `stderr` whereas
-JSON is outputted to `stdout`. Example usage:
+JSON is outputted to `stdout`. To see the list of available options, use the
+`-h` flag. Example usage:
 
     repotool ~/Code/myawesomeproject > myawesomeproject.json
 
-To insert data into the PostgreSQL database, you need to provide a configuration
-file in argument. Simply copy `repotool.conf.sample` to `repotool.conf` and
-adjust database connection information. See this
+`repotool-db` can be used to insert data into the PostgreSQL database.
+You need to provide a configuration file in argument. Simply copy
+`repotool.conf.sample` to `repotool.conf` and adjust database connection
+information at the very least. See this
 [README.md](https://github.com/DevMine/repotool/blob/master/db/README.md) for
-more information about the database schema. Example usage:
+more information about the database schema.
+`repotool-db` can be used to process multiple repositories in parallel. This is
+why, as opposed to `repotool`, it does not simply take a repository as argument
+but it takes a directory where it expects to find source code repositories. The
+depth at which repositories are expected to be found can be specified with the
+`depth` flag. To see the list of available options, use the `-h` flag. Example
+usage:
 
-    repotool -json=false -db -c repotool.conf ~/Code/myawesomeproject
+    repotool-db -c repotool.conf ~/Code
 
-With the configuration file, you can also tell `repotool` to output commit
+With the configuration file, you can also tell `repotool-db` to insert commit
 deltas and commits patches (the latter works only if you enable commit deltas,
-quite logically). Simply set the `commit_deltas` and, eventually,
-`commit_patches`, to `true`. Be careful with the `commit_patches` option as this
-may rapidly produce a lot of data. Also note that if you plan on inserting data
-into a database, patches are not going to be inserted, whether you set
-`commit_patches` to `true` or not.
+quite logically). Simply set the `commit_deltas` and to `true`. Note that the
+`commit_patches` option is ignored for now. `repotool-db` can process
+repositories concurrently by recursively traversing directories, spawning
+goroutines in the process.  When using it, bear in mind that `repotool-db` is IO
+and CPU intensive, hence do not spawn too many goroutines or you might reach the
+number of open files limit. The number of goroutines can be adjusted with the
+`-g` parameter.  Using about the same number of goroutines as the number of cpu
+cores should be a reasonable choice.
 
 As `libgit2` does not support reading information directly from a tar archive,
-when given a git repository as a tar archive, `repotool` will extract part of
-the archive into a temporary location. You can specify where using `tmp_dir`
-in the configuration file. We advise specifying a path to a ramdisk for
-increased performance and reduced main storage I/Os. When using a ramdisk with
-limited capacity, you shall specify the largest size for a tar archive to be
-extracted in `tmp_dir` using the `tmp_dir_file_size_limit` option. Every tar
-archive larger than this size will be extracted in its storage location instead.
-
-If you plan on batch processing multiple repositories, see
-[batch-repotool.go](https://github.com/DevMine/devmine/blob/master/tools/batch-repotool.go).
-It can process repositories concurrently by recursively traversing directories
-and calling `repotool`, spawning goroutines in the process.  When using it, bear
-in mind that `repotool` is IO and CPU intensive, hence do not spawn too many
-goroutines or you might reach the number of open files limit. The number of
-goroutines can be adjusted with the `-g` parameter.  Using about the same number
-of goroutines as the number of cpu cores should be a reasonable choice.
+when given a git repository as a tar archive, `repotool`, or `repotool-db` will
+extract part of the archive into a temporary location. You can specify where
+using `tmp_dir` in the configuration file for `repotool-db` or by given the
+information as argument to `repotool`. We advise specifying a path to a ramdisk
+for increased performance and reduced main storage I/Os. When using a ramdisk
+with limited capacity, you shall specify the largest size for a tar archive to
+be extracted in `tmp_dir` using the `tmp_dir_file_size_limit` option from the
+configuration file for `repotool-db` or by using the appropriate flag for
+`repotool`. Every tar archive larger than this size will be extracted in its
+storage location instead.

--- a/cmd/repotool/repotool.go
+++ b/cmd/repotool/repotool.go
@@ -1,0 +1,147 @@
+// Copyright 2014-2015 The DevMine authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package repotool is able to fetch information from a source code repository.
+// Typically, it can get all commits, their authors and commiters and so on
+// and return this information in a JSON object.
+// Currently, on the Git VCS is supported.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	"github.com/DevMine/repotool/config"
+	"github.com/DevMine/srcanlzr/src"
+
+	"github.com/DevMine/repotool/repo"
+)
+
+const version = "0.1.0"
+
+// program flags
+var (
+	vflag             = flag.Bool("v", false, "print version.")
+	srctoolflag       = flag.String("srctool", "", "read json file produced by srctool (give stdin to read from stdin)")
+	cpuprofileflag    = flag.String("cpuprofile", "", "write cpu profile to file")
+	tmpDirflag        = flag.String("tmpdir", "", "temporary directory location")
+	fileSizeLimitflag = flag.Float64("filesizelimit", 0.1, "maximum size, in GB, for a file to be processed in the temporary directory location")
+	deltasflag        = flag.Bool("deltas", false, "fetch commit deltas")
+	patchesflag       = flag.Bool("patches", false, "fetch commit patches")
+)
+
+func main() {
+	var err error
+
+	flag.Usage = func() {
+		fmt.Printf("usage: %s [OPTION(S)] [REPOSITORY PATH]\n", os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(0)
+	}
+	flag.Parse()
+
+	if *vflag {
+		fmt.Printf("%s - %s\n", filepath.Base(os.Args[0]), version)
+		os.Exit(0)
+	}
+
+	if *cpuprofileflag != "" {
+		f, err := os.Create(*cpuprofileflag)
+		if err != nil {
+			fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	if len(flag.Args()) != 1 {
+		fmt.Fprintln(os.Stderr, "invalid # of arguments")
+		flag.Usage()
+	}
+
+	cfg := new(config.Config)
+	cfg.TmpDir = *tmpDirflag
+	cfg.TmpDirFileSizeLimit = *fileSizeLimitflag
+	cfg.Data.CommitDeltas = *deltasflag
+	cfg.Data.CommitPatches = *patchesflag
+
+	repoPath := flag.Arg(0)
+	var repository repo.Repo
+	repository, err = repo.New(*cfg, repoPath)
+	if err != nil {
+		fatal(err)
+	}
+	defer func() {
+		repository.Cleanup()
+		if err != nil {
+			fatal(err)
+		}
+	}()
+
+	fmt.Fprintln(os.Stderr, "fetching repository commits...")
+	tic := time.Now()
+	err = repository.FetchCommits()
+	if err != nil {
+		return
+	}
+	toc := time.Now()
+	fmt.Fprintln(os.Stderr, "done in ", toc.Sub(tic))
+
+	if *srctoolflag == "" {
+		var bs []byte
+		bs, err = json.Marshal(repository)
+		if err != nil {
+			return
+		}
+		fmt.Println(string(bs))
+	} else {
+		var r *bufio.Reader
+		if *srctoolflag == strings.ToLower("stdin") {
+			// read from stdin
+			r = bufio.NewReader(os.Stdin)
+		} else {
+			// read from srctool json file
+			var f *os.File
+			if f, err = os.Open(*srctoolflag); err != nil {
+				return
+			}
+			r = bufio.NewReader(f)
+		}
+
+		buf := new(bytes.Buffer)
+		if _, err = io.Copy(buf, r); err != nil {
+			return
+		}
+
+		bs := buf.Bytes()
+		var p *src.Project
+		p, err = src.Unmarshal(bs)
+		if err != nil {
+			return
+		}
+
+		p.Repo = repository.GetRepository()
+		bs, err = src.Marshal(p)
+		if err != nil {
+			return
+		}
+
+		fmt.Println(string(bs))
+	}
+}
+
+// fatal prints an error on standard error stream and exits.
+func fatal(a ...interface{}) {
+	fmt.Fprintln(os.Stderr, a...)
+	os.Exit(1)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -24,8 +24,8 @@ var sslModes = map[string]bool{
 
 // Config is the main configuration structure.
 type Config struct {
-	Database DatabaseConfig `json:"database"`
-	Data     DataConfig     `json:"data"`
+	Database *DatabaseConfig `json:"database"`
+	Data     DataConfig      `json:"data"`
 
 	// TmpDir can be used to specify a temporary working directory. If
 	// left unspecified, the default system temporary directory will be used.


### PR DESCRIPTION
The rationale behind that is that `repotool` can be used two ways: to collect commits information from a repository and produce the appropriate JSON, or for database insertions. When doing database insertions, it makes more sense to process several repositories in parallel. Hence, the `batch-repotool.go` script that we used to use to do that is now no longer necessary. We will be now able to do some optimizations by processing several source code repositories at once like optimizing database requests, transactions and we also avoid creating throw-away processes and use goroutines instead.
